### PR TITLE
[AXB-54] Switch to RPC proxy endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@vercel/otel": "^1.5.0",
     "@vercel/speed-insights": "^1.0.2",
     "autoprefixer": "10.4.14",
+    "axios": "^1.9.0",
     "big.js": "^7.0.1",
     "bufferutil": "^4.0.7",
     "class-variance-authority": "^0.6.1",

--- a/src/contexts/NearContext.tsx
+++ b/src/contexts/NearContext.tsx
@@ -344,7 +344,12 @@ export const NearProvider: React.FC<NearProviderProps> = ({
     async (txhash: string) => {
       if (!selector) return null;
       const { network } = selector.options;
-      const provider = new providers.JsonRpcProvider({ url: network.nodeUrl });
+
+      const provider = new providers.JsonRpcProvider({
+        url: getRpcUrl(network.networkId, {
+          useArchivalNode: true,
+        }),
+      });
 
       // Retrieve transaction result from the network
       const transaction = await provider.txStatus(txhash, "unnused");
@@ -363,7 +368,11 @@ export const NearProvider: React.FC<NearProviderProps> = ({
     async (accountId: string) => {
       if (!selector) return "";
       const { network } = selector.options;
-      const provider = new providers.JsonRpcProvider({ url: network.nodeUrl });
+      const provider = new providers.JsonRpcProvider({
+        url: getRpcUrl(network.networkId, {
+          useArchivalNode: true,
+        }),
+      });
 
       // Retrieve account state from the network
       const account = await provider.query({
@@ -402,7 +411,11 @@ export const NearProvider: React.FC<NearProviderProps> = ({
     async (accountId: string) => {
       if (!selector) return [];
       const { network } = selector.options;
-      const provider = new providers.JsonRpcProvider({ url: network.nodeUrl });
+      const provider = new providers.JsonRpcProvider({
+        url: getRpcUrl(network.networkId, {
+          useArchivalNode: true,
+        }),
+      });
 
       // Retrieve account state from the network
       const keys = await provider.query({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -636,7 +636,7 @@ export const getRpcUrl = (
   networkId: string,
   params: { useArchivalNode: boolean }
 ) => {
-  const url = `https://${params.useArchivalNode ? "archival-" : ""}rpc.${networkId}.near.org`;
+  const url = `${process.env.NEXT_PUBLIC_NEAR_API_ENDPOINT}/${params.useArchivalNode ? "archival-rpc" : "rpc"}/${networkId}`;
   return url;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9006,6 +9006,15 @@ axios@^1.7.4:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz"


### PR DESCRIPTION
## 📝 Summary of Changes

Switch to using RPC proxy endpoint, which calls the fastNEAR RPC.

## 📦 Type of Change

Chore

## ✅ Testing

Ensure all RPC requests go to the proxy


