### PR TITLE
feat: remove participation from delegate card

### DIFF
--- a/src/components/Delegates/DelegateCardList/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCard.tsx
@@ -44,9 +44,6 @@ const DelegateCard = ({
                   currency="veNEAR"
                 />
               </span>
-              <span className="text-primary font-bold">
-                {Number(delegate.participationRate ?? 0) * 100}% Participation
-              </span>
             </div>
             <div className="min-h-[48px] px-4">
               {sanitizedTruncatedStatement ? (

--- a/src/components/Delegates/DelegateCardList/DelegateTable.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateTable.tsx
@@ -33,9 +33,6 @@ export default function DelegateTable({
               <TableHead className="h-10 text-secondary">
                 Voting power
               </TableHead>
-              <TableHead className="h-10 text-secondary">
-                Participation
-              </TableHead>
             </TableRow>
           </TableHeader>
           <InfiniteScroll

--- a/src/components/Delegates/DelegateCardList/DelegateTableRow.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateTableRow.tsx
@@ -38,7 +38,6 @@ export default function DelegateTableRow({
           "-"
         )}
       </TableCell>
-      <TableCell>{`${Number(delegate.participationRate ?? 0) * 100}%`}</TableCell>
     </TableRow>
   );
 }


### PR DESCRIPTION
We have overhauled the participation and will be adding that back in later. Keeping on the delegate card is fine for now, but let's remove from list views.