### PR TITLE
[Chore] Update yarn commands for dev/prod API environments

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,19 +1,7 @@
 /** @type {import('next').NextConfig} */
 const path = require("path");
 
-// Environment-based API endpoint configuration
-const getApiEndpoint = () => {
-  if (process.env.NEXT_PUBLIC_AGORA_ENV === "dev") {
-    return "https://near-api-158107670134.us-west1.run.app/api";
-  }
-  // Default to production
-  return "https://near-api-237405837378.us-west1.run.app/api";
-};
-
 const nextConfig = {
-  env: {
-    NEXT_PUBLIC_NEAR_API_ENDPOINT: getApiEndpoint(),
-  },
   sassOptions: {
     includePaths: [path.join(__dirname, "styles")],
   },

--- a/src/lib/api/constants.ts
+++ b/src/lib/api/constants.ts
@@ -1,4 +1,7 @@
-export const baseApiUrl = process.env.NEXT_PUBLIC_NEAR_API_ENDPOINT;
+export const baseApiUrl =
+  process.env.NEXT_PUBLIC_AGORA_ENV === "dev"
+    ? "https://near-api-158107670134.us-west1.run.app/api"
+    : "https://near-api-237405837378.us-west1.run.app/api";
 
 export const Endpoint = Object.freeze({
   Proposals: `${baseApiUrl}/proposal`,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,7 @@ import { NANO_SECONDS_IN_DAY } from "./constants";
 import Big from "big.js";
 import { NEAR_NOMINATION_EXP } from "near-api-js/lib/utils/format";
 import { utils } from "near-api-js";
+import { baseApiUrl } from "./api/constants";
 
 const { token } = Tenant.current();
 
@@ -377,7 +378,7 @@ export const getRpcUrl = (
   networkId: string,
   params: { useArchivalNode: boolean }
 ) => {
-  const url = `${process.env.NEXT_PUBLIC_NEAR_API_ENDPOINT}/${params.useArchivalNode ? "archival-rpc" : "rpc"}/${networkId}`;
+  const url = `${baseApiUrl}/${params.useArchivalNode ? "archival-rpc" : "rpc"}/${networkId}`;
   return url;
 };
 


### PR DESCRIPTION
## 📝 Summary of Changes

`yarn start` will point to prod API
`yarn start:dev` will point to dev API

Utilizes the `NEXT_PUBLIC_AGORA_ENV` env var to set dev vs prod configuration. 

## 📦 Type of Change

chore

## ✅ Testing

- Run app locally with both commands and ensure correct API is hit
