### PR TITLE
[AXB-209] Make page height full screen 

### DIFF
--- a/src/components/Layout/PageContainer.tsx
+++ b/src/components/Layout/PageContainer.tsx
@@ -14,7 +14,7 @@ export function PageContainer({ children }: Props) {
   return (
     <DialogProvider>
       <div
-        className="mx-auto max-w-[1280px] my-3 sm:my-4 px-3 sm:px-8"
+        className="mx-auto max-w-[1280px] my-3 sm:my-4 px-3 sm:px-8 min-h-screen"
         id="root-container"
       >
         <div className="bg-dotted-pattern" />


### PR DESCRIPTION
## 📝 Summary of Changes

We regressed with https://github.com/voteagora/agora-near/pull/74/files - added back the min page height so that pages take up the full viewport.  

## 📦 Type of Change

Bug

## 📸 Screenshots (if applicable)

| Before                        | After                       |
| ----------------------------- | --------------------------- |
| <img width="1918" height="931" alt="Screenshot 2025-08-03 at 11 09 43 PM" src="https://github.com/user-attachments/assets/e4a17807-ee45-4229-af6e-0d54a5cb7249" /> | <img width="1917" height="936" alt="Screenshot 2025-08-03 at 11 09 26 PM" src="https://github.com/user-attachments/assets/bf25aede-2fae-45cc-ad01-46adb4ea4cc5" />  |

---
