### PR TITLE
[AXB-216] Fix LST learn more navigation 

### DIFF
--- a/src/components/Assets/AssetsHome.tsx
+++ b/src/components/Assets/AssetsHome.tsx
@@ -4,7 +4,7 @@ import { useNear } from "@/contexts/NearContext";
 import { useVenearAccountInfo } from "@/hooks/useVenearAccountInfo";
 import { useVenearConfig } from "@/hooks/useVenearConfig";
 import { MIN_VERSION_FOR_LST_LOCKUP } from "@/lib/constants";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useMemo } from "react";
 import { LiquidStakingTokenLockWarning } from "../Dialogs/LockDialog/LiquidStakingTokenLockWarning";
 import AgoraLoader from "../shared/AgoraLoader/AgoraLoader";
 import { AssetsLandingPage } from "./AssetsLandingPage";
@@ -28,10 +28,6 @@ export const AssetsHome = memo(() => {
     return lockupVersionToCheck < MIN_VERSION_FOR_LST_LOCKUP;
   }, [accountInfo?.lockupVersion, lockupVersion]);
 
-  const handleLearnMore = useCallback(() => {
-    window.open("/info?item=fungible-token-withdrawal", "_blank");
-  }, []);
-
   if (isLoadingAccount || isLoadingVenearConfig) {
     return (
       <div className="flex flex-col w-full h-full justify-center items-center">
@@ -49,10 +45,7 @@ export const AssetsHome = memo(() => {
       {shouldShowLSTWarning && (
         <div className="w-full bg-[#F9F8F7] border-b border-gray-200 px-4 py-3 mt-4 rounded-2xl">
           <div className="mx-auto">
-            <LiquidStakingTokenLockWarning
-              symbol="liquid staking tokens"
-              onLearnMorePressed={handleLearnMore}
-            />
+            <LiquidStakingTokenLockWarning />
           </div>
         </div>
       )}

--- a/src/components/Assets/AssetsLandingPage.tsx
+++ b/src/components/Assets/AssetsLandingPage.tsx
@@ -68,11 +68,6 @@ export const AssetsLandingPage = memo(
       []
     );
 
-    const handleLearnMore = useCallback(() => {
-      // Close any dialogs and navigate to info page
-      window.open("/info?item=fungible-token-withdrawal", "_blank");
-    }, []);
-
     if (isLoadingAccount || isLoadingVenearSnapshot) {
       return (
         <div className="flex flex-col w-full h-full justify-center items-center">
@@ -86,10 +81,7 @@ export const AssetsLandingPage = memo(
         {shouldShowLSTWarning && (
           <div className="w-full bg-[#F9F8F7] border-b border-gray-200 rounded-2xl px-4 py-3 mt-4">
             <div className="max-w-6xl mx-auto">
-              <LiquidStakingTokenLockWarning
-                symbol="liquid staking tokens"
-                onLearnMorePressed={handleLearnMore}
-              />
+              <LiquidStakingTokenLockWarning />
             </div>
           </div>
         )}

--- a/src/components/Dialogs/LockDialog/LiquidStakingTokenLockWarning.tsx
+++ b/src/components/Dialogs/LockDialog/LiquidStakingTokenLockWarning.tsx
@@ -1,15 +1,17 @@
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
-import Link from "next/link";
+import { useCallback } from "react";
 
 type LiquidStakingTokenLockWarningProps = {
   symbol?: string;
-  onLearnMorePressed: () => void;
 };
 
 export const LiquidStakingTokenLockWarning = ({
   symbol,
-  onLearnMorePressed,
 }: LiquidStakingTokenLockWarningProps) => {
+  const onLearnMorePressed = useCallback(() => {
+    window.open("/info?item=fungible-token-withdrawal", "_blank");
+  }, []);
+
   return (
     <div className="flex flex-row items-start bg-[#F9F8F7] p-2 rounded-lg">
       <div>
@@ -20,15 +22,11 @@ export const LiquidStakingTokenLockWarning = ({
         />
       </div>
       <p className="text-sm ml-2">
-        Once you transfer your {symbol || "tokens"}, you will not be able to
-        withdraw without unstaking first.{" "}
-        <Link
-          onClick={onLearnMorePressed}
-          href="/info?item=fungible-token-withdrawal"
-          className="underline"
-        >
+        Once you transfer your {symbol || "liquid staking tokens"}, you will not
+        be able to withdraw without unstaking first.{" "}
+        <button onClick={onLearnMorePressed} className="underline">
           Learn more
-        </Link>
+        </button>
       </p>
     </div>
   );

--- a/src/components/Dialogs/LockDialog/LockDialogContent.tsx
+++ b/src/components/Dialogs/LockDialog/LockDialogContent.tsx
@@ -102,14 +102,12 @@ export function LockDialogContent({ closeDialog }: DialogContentProps) {
           handleLockMore={handleLockMore}
           handleProceedToStaking={proceedToStaking}
           handleViewDashboard={handleViewDashboard}
-          closeDialog={closeDialog}
         />
       );
     }
 
     return null;
   }, [
-    closeDialog,
     currentStep,
     handleTokenSelect,
     handleViewDashboard,

--- a/src/components/Dialogs/LockDialog/ReviewStep.tsx
+++ b/src/components/Dialogs/LockDialog/ReviewStep.tsx
@@ -7,6 +7,7 @@ import { UpdatedButton } from "@/components/Button";
 import { TransactionError } from "@/components/TransactionError";
 import { TooltipWithTap } from "@/components/ui/tooltip-with-tap";
 import { useDeployLockupAndLock } from "@/hooks/useDeployLockupAndLock";
+import { MIN_VERSION_FOR_LST_LOCKUP } from "@/lib/constants";
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import Big from "big.js";
 import { utils } from "near-api-js";
@@ -17,14 +18,12 @@ import { useLockProviderContext } from "../LockProvider";
 import { DepositTooltip } from "./DepositTooltip";
 import { DisclosuresContent } from "./DisclosuresContent";
 import { LiquidStakingTokenLockWarning } from "./LiquidStakingTokenLockWarning";
-import { MIN_VERSION_FOR_LST_LOCKUP } from "@/lib/constants";
 
 type ReviewStepProps = {
   handleEdit: () => void;
   handleLockMore: () => void;
   handleProceedToStaking: () => void;
   handleViewDashboard: () => void;
-  closeDialog: () => void;
 };
 
 export const ReviewStep = memo(
@@ -33,7 +32,6 @@ export const ReviewStep = memo(
     handleLockMore,
     handleProceedToStaking,
     handleViewDashboard,
-    closeDialog,
   }: ReviewStepProps) => {
     const [showDisclosures, setShowDisclosures] = useState(false);
 
@@ -325,7 +323,6 @@ export const ReviewStep = memo(
           {shouldShowLSTWarning && (
             <LiquidStakingTokenLockWarning
               symbol={selectedToken?.metadata?.name}
-              onLearnMorePressed={closeDialog}
             />
           )}
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## 📝 Summary of Changes

The liquid staking warning banner was using a `Link` for the "Learn more", which was navigating the current page to the FAQ, on top of opening a new window with the FAQ page. Fix is to remove the `Link` and just open the FAQ in a new page.

## 📦 Type of Change

Bug

## ✅ Testing

Click "Learn more" banner on `/assets` page and also when locking an LST (e.g. liNEAR)