### PR TITLE
feat: Show delegation tab for delegates with self-locked VP

### DIFF
--- a/src/components/Delegates/Delegations/DelegationsContainer.tsx
+++ b/src/components/Delegates/Delegations/DelegationsContainer.tsx
@@ -53,7 +53,14 @@ function DelegationsContainer({ address }: { address: string }) {
     return <DelegationsContainerSkeleton />;
   }
 
-  if (delegatedTo?.length === 0 && delegatedFrom?.length === 0) {
+  const hasSelfLockedVP =
+    selfLockedVotingPower && selfLockedVotingPower !== "0";
+
+  if (
+    delegatedTo?.length === 0 &&
+    delegatedFrom?.length === 0 &&
+    !hasSelfLockedVP
+  ) {
     return (
       <div className="p-8 text-center text-secondary align-middle bg-wash rounded-xl">
         No delegations found.


### PR DESCRIPTION
Prevents the delegation tab from showing 'No delegations found' when a delegate has self-locked voting power but no explicit delegation events. This supports LST users whose VP accrues without delegate_all transactions.