### PR TITLE
fix(ui): disable unlock button when not eligible and no locked balance

### DIFF
--- a/src/components/Assets/VeNearAssetRow.tsx
+++ b/src/components/Assets/VeNearAssetRow.tsx
@@ -116,13 +116,32 @@ export const VeNearAssetRow = memo<VeNearAssetRowProps>(
       ];
     }, [balanceWithRewards, pendingBalanceCol]);
 
-    const actionButton = useMemo(
-      () => ({
-        title: "Unlock",
+    const actionButton = useMemo(() => {
+      const canWithdraw = isEligibleToUnlock && hasPendingBalance;
+      const canUnlock = Number(balanceWithRewards) > 0;
+
+      if (!canWithdraw && !canUnlock) {
+        if (hasPendingBalance) {
+          return {
+            title: "Withdraw",
+            onClick: () => {},
+            disabled: true,
+            tooltip: "Wait for the unlock period to finish",
+          };
+        }
+        return undefined;
+      }
+
+      return {
+        title: canWithdraw ? "Withdraw" : "Unlock",
         onClick: handleUnlockTokens,
-      }),
-      [handleUnlockTokens]
-    );
+      };
+    }, [
+      handleUnlockTokens,
+      isEligibleToUnlock,
+      hasPendingBalance,
+      balanceWithRewards,
+    ]);
 
     return (
       <ResponsiveAssetRow


### PR DESCRIPTION
Disables the unlock button when the user has 0 locked balance and is not eligible to withdraw. Changes button text to Withdraw when eligible.